### PR TITLE
[vault] Add public chart to honestbee folder for better management

### DIFF
--- a/honestbee/vault/.helmignore
+++ b/honestbee/vault/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/honestbee/vault/Chart.yaml
+++ b/honestbee/vault/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+appVersion: 0.8.3
+description: A Helm chart for Vault, a tool for managing secrets
+home: https://www.vaultproject.io/
+icon: https://www.vaultproject.io/assets/images/mega-nav/logo-vault-0f83e3d2.svg
+maintainers:
+- email: tuan.nguyen@honestbee.com
+  name: Tuan Nguyen
+name: vault
+sources:
+- https://github.com/hashicorp/vault
+- https://github.com/hashicorp/docker-vault
+version: 0.2.0

--- a/honestbee/vault/README.md
+++ b/honestbee/vault/README.md
@@ -1,0 +1,68 @@
+# Vault Helm Chart
+
+This directory contains a Kubernetes chart to deploy a Vault server.
+
+## Prerequisites Details
+
+* Kubernetes 1.5
+
+## Chart Details
+
+This chart will do the following:
+
+* Implement a Vault deployment
+
+Please note that a backend service for Vault (for example, Consul) must
+be deployed beforehand and configured with the `vault` option. YAML provided
+under this option will be converted to JSON for the final vault `config.json`
+file.
+
+> See https://www.vaultproject.io/docs/configuration/ for more information.
+
+## Installing the Chart
+
+To install the chart, use the following, this backs vault with a Consul cluster:
+
+```console
+$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+$ helm install incubator/vault --set vault.storage.consul.address="myconsul-svc-name:8500",vault.storage.consul.path="vault"
+```
+
+An alternative example using the Amazon S3 backend can be specified using:
+
+```
+vault:
+  storage:
+    s3:
+      access_key: "AWS-ACCESS-KEY"
+      secret_key: "AWS-SECRET-KEY"
+      bucket: "AWS-BUCKET"
+      region: "eu-central-1"
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the vault chart and their default values.
+
+|       Parameter         |           Description               |                         Default                     |
+|-------------------------|-------------------------------------|-----------------------------------------------------|
+| `image.pullPolicy`      | Container pull policy               | `IfNotPresent`                                      |
+| `image.repository`      | Container image to use              | `vault`                                             |
+| `image.tag`             | Container image tag to deploy       | `0.7.3`                                             |
+| `vault`                 | Vault configuration                 | No default backend                                  |
+| `replicaCount`          | k8s replicas                        | `1`                                                 |
+| `resources.limits.cpu`  | Container requested CPU             | `nil`                                               |
+| `resources.limits.memory` | Container requested memory        | `128Mi`                                             |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+## Using Vault
+
+Once the Vault pod is ready, it can be accessed using a `kubectl
+port-forward`:
+
+```console
+$ kubectl port-forward vault-pod 8200
+$ export VAULT_ADDR=http://127.0.0.1:8200
+$ vault status
+```

--- a/honestbee/vault/templates/NOTES.txt
+++ b/honestbee/vault/templates/NOTES.txt
@@ -1,0 +1,17 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.hostname }}
+  http://{{- .Values.ingress.hostname }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Use http://127.0.0.1:8200 as the Vault address after forwarding."
+  kubectl port-forward $POD_NAME 8200:{{ .Values.service.port }}
+{{- end }}

--- a/honestbee/vault/templates/_helpers.tpl
+++ b/honestbee/vault/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "internal.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name "internal" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/honestbee/vault/templates/configmap.yaml
+++ b/honestbee/vault/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "fullname" . }}"
+  labels:
+    app: "{{ template "name" . }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+data:
+  config.json: |
+    {{ .Values.vault | toJson }}

--- a/honestbee/vault/templates/deployment.yaml
+++ b/honestbee/vault/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    checksum/config-map: {{ include (print $.Chart.Name "/templates/configmap.yaml") . | sha256sum }}
+    checksum/secret: {{ include (print $.Chart.Name "/templates/secret.yaml") . | sha256sum }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.vaultmode.dev }}
+        command: ["vault", "server", "-dev"]
+        {{- else }}
+        command: ["vault", "server", "-config", "/vault/config/config.json"]
+        {{- end }}
+        env:
+        # populate secrets
+        {{- range $key, $value :=  .Values.secrets }}
+        - name: {{ $key | upper | replace "-" "_" }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "fullname" $ }}
+              key: {{ $key }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.service.port }}
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.service.port }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.service.port }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          capabilities:
+            add:
+            - IPC_LOCK
+        volumeMounts:
+        - name: vault-config
+          mountPath: /vault/config/
+        - name: vault-root
+          mountPath: /root/
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+      volumes:
+        - name: vault-config
+          configMap:
+            name: "{{ template "fullname" . }}"
+        - name: vault-root
+          emptyDir: {}

--- a/honestbee/vault/templates/ingress-internal.yaml
+++ b/honestbee/vault/templates/ingress-internal.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingressInternal.enabled -}}
+{{- $serviceName := include "fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "internal.fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    {{- range $key, $value := .Values.ingressInternal.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingressInternal.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingressInternal.tls }}
+  tls:
+{{ toYaml .Values.ingressInternal.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/honestbee/vault/templates/ingress.yaml
+++ b/honestbee/vault/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/honestbee/vault/templates/secret.yaml
+++ b/honestbee/vault/templates/secret.yaml
@@ -1,0 +1,15 @@
+# Create a kubernetes secret and expose via ENV for sensitive data instead
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "fullname" . }}
+type: Opaque
+data:
+  {{- range $key, $value :=  .Values.secrets }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}

--- a/honestbee/vault/templates/service.yaml
+++ b/honestbee/vault/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    {{- if .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort}}
+    {{- end }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}

--- a/honestbee/vault/values.yaml
+++ b/honestbee/vault/values.yaml
@@ -1,0 +1,81 @@
+# Default values for vault.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: vault
+  tag: 0.7.3
+  pullPolicy: Always
+service:
+  name: vault
+  type: ClusterIP
+  port: 8200
+  externalPort: 8200
+  # define nodePort if type: NodePort
+  # nodePort: 1111
+ingress:
+  enabled: false
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - chart-example.local
+  annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+ingressInternal:
+  enabled: true
+  # Used to create Ingress record (should used with service.type: ClusterIP).
+  hosts:
+    - chart-example.local
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+# A YAML representation of a final vault config.json file.
+# See https://www.vaultproject.io/docs/configuration/ for more information.
+vaultmode:
+# Only used to enable dev mode. When in dev mode, the rest of this configuration
+# is ignored. See https://www.vaultproject.io/intro/getting-started/dev-server.html
+# for more information.
+  dev: false
+vault:
+  listener:
+    tcp:
+      address: '0.0.0.0:8200'
+      tls_disable: 1
+# See https://www.vaultproject.io/docs/configuration/storage/ for storage backends
+  storage:
+    #consul:
+    #  address: ""
+    #  path: ""
+    #
+    #etcd:
+    #  address: ""
+    #  path: "vault/"
+    #
+    #s3:
+    #  bucket: ""
+    #  region: ""
+    #  access_key: ""
+    #  secret_key: ""
+    #  endpoint: "" # When not using AWS S3
+resources:
+  limits:
+#    cpu: 100m
+    memory: 128Mi
+  requests:
+#    cpu: 100m
+    memory: 128Mi
+
+secrets:
+  aws-access-key-id: "111"
+  aws-secret-access-key: "222"
+


### PR DESCRIPTION
## Why?
- Add `honestbee/` folder to contain customized charts which specifically use for honestbee Infrastructure.
- Add `vault` public chart.
- Bump `vault` chart version to `0.2.0`.
- Add internal ingress.